### PR TITLE
[issue 4] Testsuite: Docker PostgreSQL: FATAL: the database system is…

### DIFF
--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -299,8 +299,11 @@
                                         <container.database.name>narayana_db</container.database.name>
                                         <container.database.bind.host.ip>127.0.0.1</container.database.bind.host.ip>
                                         <container.database.bind.host.port>5432</container.database.bind.host.port>
-                                        <!-- The undermentioned timeout accounts both for pulling image and starting container. Might be split into two timeouts in future. -->
+                                        <!-- The undermentioned timeout accounts both for pulling image and starting container up to opened socket. -->
                                         <container.timeout.waiting.for.tcp>240000</container.timeout.waiting.for.tcp>
+
+                                        <db.timeout.waiting.for.heartbeat.statement>30000</db.timeout.waiting.for.heartbeat.statement>
+                                        <db.timeout.heartbeat.statement>SELECT 1;</db.timeout.heartbeat.statement>
 
                                         <!-- dballocator properties -->
                                         <dballocator.host.port>http://your.db.allocator.example.com:8080</dballocator.host.port>

--- a/tools/src/main/java/io/narayana/db/Allocator.java
+++ b/tools/src/main/java/io/narayana/db/Allocator.java
@@ -41,6 +41,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -121,24 +122,33 @@ public abstract class Allocator {
      * <p>
      * Executes a simple SELECT 1 statement to verify the DB actually does something.
      *
-     * @param dbUrl            JDBC connection URL
-     * @param user             DB user
-     * @param pass             DB password
-     * @param driverClass      e.g. org.postgresql.Driver
-     * @param pathToDriverJar  Either a downloaded driver jar or a one from ShrinkWrap Maven resolver
-     * @param overallTimeoutMs How long do we keep trying with 1000ms pause in between
+     * @param db, used as:
+     *            dbUrl            JDBC connection URL
+     *            user             DB user
+     *            pass             DB password
+     *            driverClass      e.g. org.postgresql.Driver
+     *            pathToDriverJar  Either a downloaded driver jar or a one from ShrinkWrap Maven resolver
+     *            overallTimeoutMs How long do we keep trying with 1000ms pause in between
      * @return true on success
      * @throws ClassNotFoundException Fix the driver class name
      * @throws MalformedURLException  Fix the driver jar path
      */
-    public static boolean executeTestStatement(
-            final String dbUrl, final String user, final String pass, final String driverClass, final String pathToDriverJar, final long overallTimeoutMs)
+    public static boolean executeTestStatement(final DB db, final String pathToDriverJar)
             throws ClassNotFoundException, MalformedURLException, IllegalAccessException, InstantiationException, SQLException {
 
-        final String sql = "SELECT 1;";
+        final String overallTimeout = getProp("db.timeout.waiting.for.heartbeat.statement");
+        final long overallTimeoutMs = Long.parseLong(overallTimeout);
+        if (overallTimeoutMs > TimeUnit.MINUTES.toMillis(5) || overallTimeoutMs < 100) {
+            throw new IllegalArgumentException("db.timeout.waiting.for.heartbeat.statement out of expected range [100, 5*60*1000] ms.");
+        }
+        if (StringUtils.isBlank(db.heartBeatStatement)) {
+            throw new IllegalArgumentException("db.heartBeatStatement on DB object must be set," +
+                    "check your *Allocator class and db.timeout.heartbeat.statement property.");
+        }
+
         final long timestamp = System.currentTimeMillis();
         final URLClassLoader ucl = new URLClassLoader(new URL[]{new URL(String.format("jar:file:%s!/", pathToDriverJar))});
-        final Driver driver = (Driver) Class.forName(driverClass, true, ucl).newInstance();
+        final Driver driver = (Driver) Class.forName(db.dsDriverClassName, true, ucl).newInstance();
 
         DriverManager.registerDriver(new Driver() {
             @Override
@@ -179,9 +189,9 @@ public abstract class Allocator {
 
         while (System.currentTimeMillis() - timestamp < overallTimeoutMs) {
             try (
-                    final Connection conn = DriverManager.getConnection(dbUrl, user, pass);
+                    final Connection conn = DriverManager.getConnection(db.dsUrl, db.dsUser, db.dsPassword);
                     final Statement stmt = conn.createStatement();
-                    final ResultSet rs = stmt.executeQuery(sql)
+                    final ResultSet rs = stmt.executeQuery(db.heartBeatStatement)
             ) {
                 if (rs.next()) {
                     return true;
@@ -189,7 +199,7 @@ public abstract class Allocator {
             } catch (Exception e) {
                 long remainingTime = overallTimeoutMs - (System.currentTimeMillis() - timestamp);
                 LOGGER.log(Level.SEVERE, String.format("DB not ready to answer the test statement: %s. Remaining time: %d, approx %d attempts.",
-                        sql, remainingTime, remainingTime / 1000), e);
+                        db.heartBeatStatement, remainingTime, remainingTime / 1000), e);
             }
             try {
                 Thread.sleep(1000);

--- a/tools/src/main/java/io/narayana/db/DB.java
+++ b/tools/src/main/java/io/narayana/db/DB.java
@@ -43,6 +43,7 @@ public class DB {
     public final String tdsUrl;
     public final String tdsDriverClassName;
     public final String dbDriverArtifact;
+    public final String heartBeatStatement;
     public final Properties allocationProperties;
 
     public static class Builder {
@@ -61,6 +62,7 @@ public class DB {
         private String tdsUrl;
         private String tdsDriverClassName;
         private String dbDriverArtifact;
+        private String heartBeatStatement;
         private Properties allocationProperties;
 
         Builder dsType(String dsType) {
@@ -138,6 +140,11 @@ public class DB {
             return this;
         }
 
+        Builder heartBeatStatement(String heartBeatStatement) {
+            this.heartBeatStatement = heartBeatStatement;
+            return this;
+        }
+
         Builder allocationProperties(Properties allocationProperties) {
             this.allocationProperties = allocationProperties;
             return this;
@@ -164,6 +171,7 @@ public class DB {
         this.tdsUrl = builder.tdsUrl;
         this.tdsDriverClassName = builder.tdsDriverClassName;
         this.dbDriverArtifact = builder.dbDriverArtifact;
+        this.heartBeatStatement = builder.heartBeatStatement;
         this.allocationProperties = builder.allocationProperties;
     }
 }

--- a/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
+++ b/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
@@ -94,11 +94,12 @@ public class PostgreContainerAllocator extends Allocator {
         final String containerTimeoutWaitingForTcp = getProp("container.timeout.waiting.for.tcp");
         final long timeout = Long.parseLong(containerTimeoutWaitingForTcp);
         if (timeout > TimeUnit.MINUTES.toMillis(30) || timeout < 500) {
-            throw new IllegalArgumentException("container.timeout.waiting.for.tcp out of expected range [500, 30*60*1000]");
+            throw new IllegalArgumentException("container.timeout.waiting.for.tcp out of expected range [500, 30*60*1000] ms.");
         }
         final String containerDatabaseDriverArtifact = getProp("container.database.driver.artifact");
         final String containerDatabaseDriverClass = getProp("container.database.driver.class");
         final String containerDatabaseDatasourceClassXa = getProp("container.database.datasource.class.xa");
+        final String heartBeatStatement = getProp("db.timeout.heartbeat.statement");
 
         final AtomicBoolean completed = new AtomicBoolean(false);
 
@@ -228,6 +229,7 @@ public class PostgreContainerAllocator extends Allocator {
                 .dsDriverClassName(containerDatabaseDriverClass)
                 .tdsType("javax.sql.XADataSource")
                 .dbDriverArtifact(containerDatabaseDriverArtifact)
+                .heartBeatStatement(heartBeatStatement)
                 .build();
     }
 

--- a/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
+++ b/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
@@ -185,15 +185,6 @@ public class PostgreContainerAllocator extends Allocator {
                         LOGGER.info(String.format("The database container has successfully opened TCP socket %s:%d", containerDatabaseBindHostIp, port));
                     }
 
-                    // TODO - replace with a logical check - an SQL statement.
-                    // Sometimes it takes a jiffy to avoid "PSQLException: the database system is starting up"
-                    try {
-                        Thread.sleep(10000);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        LOGGER.log(Level.SEVERE, "Interrupted.", e);
-                    }
-
                     completed.set(true);
                 }
 


### PR DESCRIPTION
… starting up #4 

Adds a new method that tries to dynamicaly load the given DB driver and uses JDBC to
execute a simple SELECT 1; statement. The method is then used just after DB initialization.

The rudimentary check for TCP port was not enough, this check makes the DB allocation more robust.