### PR TITLE
Testsuite: Increases timeout for initial heartbeat from 30s to 120s

### DIFF
--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -302,7 +302,7 @@
                                         <!-- The undermentioned timeout accounts both for pulling image and starting container up to opened socket. -->
                                         <container.timeout.waiting.for.tcp>240000</container.timeout.waiting.for.tcp>
 
-                                        <db.timeout.waiting.for.heartbeat.statement>30000</db.timeout.waiting.for.heartbeat.statement>
+                                        <db.timeout.waiting.for.heartbeat.statement>120000</db.timeout.waiting.for.heartbeat.statement>
                                         <db.timeout.heartbeat.statement>SELECT 1;</db.timeout.heartbeat.statement>
 
                                         <!-- dballocator properties -->

--- a/tools/src/main/java/io/narayana/db/Allocator.java
+++ b/tools/src/main/java/io/narayana/db/Allocator.java
@@ -197,7 +197,7 @@ public abstract class Allocator {
                     return true;
                 }
             } catch (Exception e) {
-                long remainingTime = overallTimeoutMs - (System.currentTimeMillis() - timestamp);
+                long remainingTime = Math.max(0, overallTimeoutMs - (System.currentTimeMillis() - timestamp));
                 LOGGER.log(Level.SEVERE, String.format("DB not ready to answer the test statement: %s. Remaining time: %d, approx %d attempts.",
                         db.heartBeatStatement, remainingTime, remainingTime / 1000), e);
             }


### PR DESCRIPTION
OpenStack slave could have a weird I/O pauses that sometimes cause the database to take a really long
time to start. Also note that the timeout is absolute, so eventhough the Thread sleep is 1s,
there could be as few as 4 attempts in the 30s window.

Furthermore, the commit fixes logging glitch:

```
SEVERE: DB not ready to answer the test statement: SELECT 1;. Remaining time: -1793, approx -1 attempts.
org.postgresql.util.PSQLException: FATAL: the database system is starting up
```

With ```... = Math.max(0, overallTimeoutMs - (System.currentTimeMillis() - timestamp));```