### PR TITLE
Adds check for DB's ability to execute test SELECT 1; statement also …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /bin/
+tomcat-jta/dependency-reduced-pom.xml

--- a/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/BaseITCase.java
+++ b/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/BaseITCase.java
@@ -129,6 +129,7 @@ public class BaseITCase extends AbstractCase {
         deployer.undeploy("Basic-app");
         controller.stop("tomcat");
         assertTrue("Failed to clean DB, check logs for the root cause.", dba.cleanDB(db));
+        executeTestStatement(dbDriverAbsolutePath, db, dba);
     }
 
     @Test


### PR DESCRIPTION
…to cleanDB method

Previous commits introduced a SELECT 1; "heartbeat" statement used just after the TCP
socket is opened to check that the DB is really ready and not "Starting...".
This check is needed for cleanDB too, because the container is completely restarted
from a fresh image on clean up.