### PR TITLE
Update GAV to include renamed group and artifact ids and new version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
         <artifactId>jboss-parent</artifactId>
         <version>28</version>
     </parent>
-    <groupId>org.jboss.narayana.tomcat</groupId>
-    <artifactId>tomcat-all</artifactId>
-    <version>5.0.1.Final-SNAPSHOT</version>
+    <groupId>org.jboss.integration</groupId>
+    <artifactId>narayana-tomcat-all</artifactId>
+    <version>1.0.0.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Narayana: Tomcat integration</name>
     <build>

--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -25,9 +25,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jboss.narayana.tomcat</groupId>
-        <artifactId>tomcat-all</artifactId>
-        <version>5.0.1.Final-SNAPSHOT</version>
+        <groupId>org.jboss.integration</groupId>
+        <artifactId>narayana-tomcat-all</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>narayana-tomcat</artifactId>
@@ -156,7 +156,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.narayana.tomcat</groupId>
+            <groupId>org.jboss.integration</groupId>
             <version>${project.version}</version>
             <artifactId>test-utils</artifactId>
             <scope>test</scope>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jboss.narayana.tomcat</groupId>
-        <artifactId>tomcat-all</artifactId>
-        <version>5.0.1.Final-SNAPSHOT</version>
+        <groupId>org.jboss.integration</groupId>
+        <artifactId>narayana-tomcat-all</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <artifactId>test-utils</artifactId>


### PR DESCRIPTION
I don't use maven much, so I'm not sure if changing the packaging references and location to reflect the new group/artifact id is necessary or not.

This closes #7