### PR TITLE
Adds checkstyle plugin configuration and Wildfly rules with supress c…

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress checks="RedundantModifier" message="Redundant 'final' modifier" files=".java"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,16 +34,6 @@
     <version>1.0.0.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Narayana: Tomcat integration</name>
-    <build>
-        <plugins>
-            <plugin>
-                <inherited>false</inherited>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${version.org.sonatype.plugins.nexus-staging-maven-plugin}</version>
-            </plugin>
-        </plugins>
-    </build>
     <properties>
         <version.org.apache.tomcat>9.0.11</version.org.apache.tomcat>
         <version.org.jboss.narayana>5.8.2.Final</version.org.jboss.narayana>
@@ -61,11 +51,63 @@
         <version.postgresql>9.0-801.jdbc4</version.postgresql>
         <version.com.github.docker-java>3.0.14</version.com.github.docker-java>
         <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
+        <version.checkstyle>8.5</version.checkstyle>
+        <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
+
+        <!-- Checkstyle configuration -->
+        <linkXRef>false</linkXRef>
     </properties>
     <modules>
         <module>tools</module>
         <module>tomcat-jta</module>
     </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <inherited>false</inherited>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${version.org.sonatype.plugins.nexus-staging-maven-plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${version.checkstyle.plugin}</version>
+                <executions>
+                    <execution>
+                        <id>check-style</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.wildfly.checkstyle</groupId>
+                        <artifactId>wildfly-checkstyle-config</artifactId>
+                        <version>${version.org.wildfly.checkstyle-config}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>wildfly-checkstyle/checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <excludes>**/*$logger.java,**/*$bundle.java</excludes>
+                    <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+                    <useFile></useFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.checkstyle</groupId>
+            <artifactId>wildfly-checkstyle-config</artifactId>
+            <version>${version.org.wildfly.checkstyle-config}</version>
+        </dependency>
+    </dependencies>
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
…onfig

The setup should help the project to maintain certain standard of style closely associated to Wildfly.
The checkstyle-supressions.xml file is here to both streamline the configuration for anyone
and to add an exception to redundant final modifiers. I personally find it O.K. and it subjectively helps
me to navigate variables purposes in code. If you think the redundant final modifiers should be
removed, I remove them though.

Occurences are purely a matter of style IMHO:
```
[ERROR] Allocator.java:100:18: Redundant 'final' modifier. [RedundantModifier]
[ERROR] Allocator.java:192:21: Redundant 'final' modifier. [RedundantModifier]
[ERROR] Allocator.java:193:21: Redundant 'final' modifier. [RedundantModifier]
[ERROR] Allocator.java:194:21: Redundant 'final' modifier. [RedundantModifier]
[ERROR] DBAllocator.java:152:14: Redundant 'final' modifier. [RedundantModifier]
```
Suppressed now.