### PR TITLE
Arq sets java.library.path to LD_LIBRARY_PATH to enable Tomcat Native

### DIFF
--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -33,12 +33,13 @@
     <artifactId>narayana-tomcat</artifactId>
     <name>Narayana: Tomcat JTA integration</name>
     <properties>
+        <java.library.path>${env.LD_LIBRARY_PATH}</java.library.path>
         <jvm.args.debug></jvm.args.debug>
         <jvm.args.byteman>
             -Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all
             -javaagent:${project.build.directory}/lib/byteman.jar=script:${project.build.directory}/test-classes/scripts.btm,listener:true
         </jvm.args.byteman>
-        <server.jvm.args>${jvm.args.byteman} ${jvm.args.debug}</server.jvm.args>
+        <server.jvm.args>-Djava.security.egd=file:/dev/urandom ${java.library.path} ${jvm.args.byteman} ${jvm.args.debug}</server.jvm.args>
     </properties>
     <dependencies>
         <dependency>

--- a/tomcat-jta/src/test/resources/arquillian.xml
+++ b/tomcat-jta/src/test/resources/arquillian.xml
@@ -36,7 +36,7 @@
             <property name="user">${tomcat.user}</property>
             <property name="pass">${tomcat.pass}</property>
             <!--  -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000 -->
-            <property name="javaVmArguments">-Djava.security.egd=file:/dev/./urandom ${server.jvm.args}</property>
+            <property name="javaVmArguments">${server.jvm.args}</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
Arquillian tests start Tomcat with natives enabled, if natives are available:

```
org.apache.catalina.core.AprLifecycleListener.lifecycleEvent 
    Loaded APR based Apache Tomcat Native library [1.2.17] using APR version [1.6.3].
org.apache.catalina.core.AprLifecycleListener.lifecycleEvent
    APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true].
org.apache.catalina.core.AprLifecycleListener.lifecycleEvent
    APR/OpenSSL configuration: useAprConnector [false], useOpenSSL [true]
org.apache.catalina.core.AprLifecycleListener.initializeSSL
    OpenSSL successfully initialized [OpenSSL 1.0.2n  7 Dec 2017]
```