### PR TITLE
Add TransactionLifecycleListener for initializing Narayana before global resources

### DIFF
--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -171,7 +171,7 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
             <version>${version.org.apache.tomcat}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>

--- a/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionLifecycleListener.java
+++ b/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionLifecycleListener.java
@@ -42,7 +42,7 @@ public class TransactionLifecycleListener implements LifecycleListener {
           .asList(ExpiredTransactionStatusManagerScanner.class.getName());
 
     /**
-     * Lifecycle.START_EVENT:
+     * Lifecycle.BEFORE_START_EVENT:
      * <p>
      * Initialize and start Narayana JTA services.
      * <p>
@@ -60,7 +60,7 @@ public class TransactionLifecycleListener implements LifecycleListener {
      * <p>
      * After setup recovery manager, transaction status manager, and transaction reaper are started.
      * <p>
-     * Lifecysle.STOP_EVENT:
+     * Lifecysle.BEFORE_STOP_EVENT:
      * <p>
      * Destroying Narayana JTA services.
      * <p>
@@ -84,7 +84,7 @@ public class TransactionLifecycleListener implements LifecycleListener {
       } else if (Lifecycle.BEFORE_STOP_EVENT.equals(event.getType())) {
           LOGGER.fine("Disabling Narayana");
           TransactionReaper.terminate(false);
-          TxControl.disable(true);
+          TxControl.disable();
           RecoveryManager.manager().terminate();
           Collections.list(DriverManager.getDrivers()).stream().filter(d -> d instanceof TransactionalDriver)
               .forEach(d -> {

--- a/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionLifecycleListener.java
+++ b/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionLifecycleListener.java
@@ -1,0 +1,153 @@
+package org.jboss.narayana.tomcat.jta;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
+
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.common.recoveryPropertyManager;
+import com.arjuna.ats.arjuna.coordinator.TransactionReaper;
+import com.arjuna.ats.arjuna.coordinator.TxControl;
+import com.arjuna.ats.arjuna.recovery.RecoveryManager;
+import com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule;
+import com.arjuna.ats.internal.arjuna.recovery.ExpiredTransactionStatusManagerScanner;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
+import com.arjuna.ats.jdbc.TransactionalDriver;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+
+public class TransactionLifecycleListener implements LifecycleListener {
+
+  private static final Logger LOGGER = Logger.getLogger(TransactionLifecycleListener.class.getSimpleName());
+
+  private static final String DEFAULT_NODE_IDENTIFIER = "1";
+
+  private static final List<String> DEFAULT_RECOVERY_MODULES = Arrays.asList(AtomicActionRecoveryModule.class.getName(),
+          XARecoveryModule.class.getName());
+
+  private static final List<String> DEFAULT_ORPHAN_FILTERS = Arrays
+          .asList(JTATransactionLogXAResourceOrphanFilter.class.getName(), JTANodeNameXAResourceOrphanFilter.class.getName());
+
+  private static final List<String> DEFAULT_EXPIRY_SCANNERS = Arrays
+          .asList(ExpiredTransactionStatusManagerScanner.class.getName());
+
+    /**
+     * Lifecycle.START_EVENT:
+     * <p>
+     * Initialize and start Narayana JTA services.
+     * <p>
+     * During the setup node identifier, recovery modules, orphan filters, and expiry scanners are setup. Configuration file
+     * will be used to get initial values. If one doesn't exist, following defaults will be used.
+     * The settings from configuration file is transfered to {@link com.arjuna.ats.jta.common.JTAEnvironmentBean} where runtime
+     * configuration resides.
+     * <p>
+     * <ul>
+     * <li>Node identifier: "1"
+     * <li>Recovery modules: {@link AtomicActionRecoveryModule}, {@link XARecoveryModule}
+     * <li>Orphan filters: {@link JTATransactionLogXAResourceOrphanFilter}, {@link JTANodeNameXAResourceOrphanFilter}
+     * <li>Expiry scanners: {@link ExpiredTransactionStatusManagerScanner}
+     * </ul>
+     * <p>
+     * After setup recovery manager, transaction status manager, and transaction reaper are started.
+     * <p>
+     * Lifecysle.STOP_EVENT:
+     * <p>
+     * Destroying Narayana JTA services.
+     * <p>
+     * First, stop recovery manager, transaction status manager, and transaction reaper. Then, remove transactional driver from
+     * jdbc driver manager's list.
+     *
+     * @param event
+     *          containing the LifecycleEvent
+     */
+  @Override
+  public void lifecycleEvent(LifecycleEvent event) {
+      if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+          LOGGER.fine("Initializing Narayana");
+          initNodeIdentifier();
+          initRecoveryModules();
+          initOrphanFilters();
+          initExpiryScanners();
+          RecoveryManager.manager();
+          TxControl.enable();
+          TransactionReaper.instantiate();
+      } else if (Lifecycle.BEFORE_STOP_EVENT.equals(event.getType())) {
+          LOGGER.fine("Disabling Narayana");
+          TransactionReaper.terminate(false);
+          TxControl.disable(true);
+          RecoveryManager.manager().terminate();
+          Collections.list(DriverManager.getDrivers()).stream().filter(d -> d instanceof TransactionalDriver)
+              .forEach(d -> {
+                  try {
+                      DriverManager.deregisterDriver(d);
+                  } catch (SQLException e) {
+                      LOGGER.log(Level.WARNING, e.getMessage(), e);
+                  }
+              });
+      }
+  }
+
+  /**
+   * If node identifier wasn't set by property manager, then set default {@link #DEFAULT_NODE_IDENTIFIER}.
+   */
+  private void initNodeIdentifier() {
+      if (arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier() == null) {
+          LOGGER.warning("Node identifier was not set. Setting it to the default value: " + DEFAULT_NODE_IDENTIFIER);
+          try {
+              arjPropertyManager.getCoreEnvironmentBean().setNodeIdentifier(DEFAULT_NODE_IDENTIFIER);
+          } catch (CoreEnvironmentBeanException e) {
+              LOGGER.log(Level.WARNING, e.getMessage(), e);
+          }
+      }
+
+      jtaPropertyManager.getJTAEnvironmentBean()
+              .setXaRecoveryNodes(Collections.singletonList(arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier()));
+  }
+
+  /**
+   * If recovery modules were not set by property manager, then set defaults {@link #DEFAULT_RECOVERY_MODULES}.
+   */
+  private void initRecoveryModules() {
+      if (!recoveryPropertyManager.getRecoveryEnvironmentBean().getRecoveryModuleClassNames().isEmpty()) {
+          return;
+      }
+
+      LOGGER.fine("Recovery modules were not enabled. Enabling default modules: " + DEFAULT_RECOVERY_MODULES);
+      recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryModuleClassNames(DEFAULT_RECOVERY_MODULES);
+  }
+
+  /**
+   * If orphan filters were not set by property manager, then set defaults {@link #DEFAULT_ORPHAN_FILTERS}.
+   */
+  private void initOrphanFilters() {
+      if (!jtaPropertyManager.getJTAEnvironmentBean().getXaResourceOrphanFilterClassNames().isEmpty()) {
+          return;
+      }
+
+      LOGGER.fine("Orphan filters were not enabled. Enabling default filters: " + DEFAULT_ORPHAN_FILTERS);
+      jtaPropertyManager.getJTAEnvironmentBean().setXaResourceOrphanFilterClassNames(DEFAULT_ORPHAN_FILTERS);
+  }
+
+  /**
+   * If expiry scanners were not set by property manager, then set defaults {@link #DEFAULT_EXPIRY_SCANNERS}.
+   */
+  private void initExpiryScanners() {
+      if (!recoveryPropertyManager.getRecoveryEnvironmentBean().getExpiryScannerClassNames().isEmpty()) {
+          return;
+      }
+
+      LOGGER.fine("Expiry scanners were not enabled. Enabling default scanners: " + DEFAULT_EXPIRY_SCANNERS);
+      recoveryPropertyManager.getRecoveryEnvironmentBean().setExpiryScannerClassNames(DEFAULT_EXPIRY_SCANNERS);
+  }
+
+}


### PR DESCRIPTION
For Narayana usage in global resource context, it must be initialized first. LifecycleListener in this case has the same role as NarayanaJtaServletContextListener in servlet context.

But, this implementation has one issue. When I kill tomcat process (started by "catalina.bat run" , stoped by "Ctrl-C"), there is error with shutdownHook.

> org.apache.catalina.LifecycleException:  Failed to stop component [StandardServer[-1]]
>	at org.apache.catalina.util.LifecycleBase.handleSubClassException(LifecycleBase.java:441)
>	at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:267)
>	at org.apache.catalina.startup.Catalina.stop(Catalina.java:755)
>	at org.apache.catalina.startup.Catalina$CatalinaShutdownHook.run(Catalina.java:856)
>Caused by: java.lang.IllegalStateException: Shutdown in progress
>	at java.lang.ApplicationShutdownHooks.remove(Unknown Source)
>	at java.lang.Runtime.removeShutdownHook(Unknown Source)
>	at com.arjuna.ats.arjuna.coordinator.TxControl.removeTransactionStatusManager(TxControl.java:201)
>	at com.arjuna.ats.arjuna.coordinator.TxControl.disable(TxControl.java:131)
>	at org.jboss.narayana.tomcat.jta.TransactionLifecycleListener.lifecycleEvent(TransactionLifecycleListener.java:87)
>	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
>	at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:424)
>	at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:254)

I think that, for embedded usage like this, some configuration option for creating shutdownlHook would be benefical.