### PR TITLE
Add support for external DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The fourth **and the most versatile mode** is to control a Docker daemon and to 
 containers. The test suite expects a Docker daemon listening to its REST commands and nothing else. 
 No special or pre-fetched images or local dependencies are expected. Postgres family of databases is currently implemented.
 
+## 5. External Database
+
+With this option, the test suite relies on an external database to be running and details on how to connect to it must be provided.
+
 # Examples
 
 All undermentioned examples expect a Tomcat installation pointed to by ```CATALINA_HOME``` env var. Certain users (mandatory) and logging (convenient) settings are also listed:
@@ -132,6 +136,18 @@ It is noteworthy that the test suite retrieves trace log from the database conta
 ```
 
 The container based testing is used upstream.
+
+## 4. External Database
+Run the TS:
+
+```bash
+mvn integration-test -Parq-tomcat -Dtomcat.user=arquillian -Dtomcat.pass=arquillian  -Dtest.db.type=external  \ 
+    -Djdbc.driver.jar=~/h2.jar -Djdbc.url="jdbc:h2:mem:test;MVCC=true"  \
+    -Djdbc.username=sa -Djdbc.password=sa -Ddatasource.classname=org.h2.jdbcx.JdbcDataSource  \
+    -Djdbc.driver.class=org.h2.Driver -Djdbc.db.name=test
+```
+
+For some database systems, different options might be required. Please see the corresponding maven profile for a complete set of supported options.
 
 # Jenkins job
 

--- a/tomcat-jta/pom.xml
+++ b/tomcat-jta/pom.xml
@@ -39,6 +39,7 @@
             -javaagent:${project.build.directory}/lib/byteman.jar=script:${project.build.directory}/test-classes/scripts.btm,listener:true
         </jvm.args.byteman>
         <server.jvm.args>${jvm.args.byteman} ${jvm.args.debug}</server.jvm.args>
+        <test.db.type/>
     </properties>
     <dependencies>
         <dependency>
@@ -223,6 +224,24 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <properties>
+                <!--
+                    h2:
+                      By default, the integration test runs with "h2" database, platform independent and in-memory.
+                    pgsql:
+                      If selected, the TS runs against a remote, always present PostgreSQL database server available in the Narayana CI.
+                    container:
+                      It requires a running Docker daemon the user executing this TS has the rights to control
+                      A database is started as a Docker container and it is discarded at the end of testing.
+                    dballocator:
+                      It requires an instance of DBAllocator running in your infrastructure. It enables the TS to
+                      lease various databases, including but not limited to Sybase, DB2, MS SQL, Maria, Postgress, Oracle...
+                    external:
+                      External database is used and the caller is responsible for running it and providing details how
+                      to connect to it.
+                -->
+                <test.db.type>h2</test.db.type>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
@@ -232,91 +251,49 @@
                 </dependency>
             </dependencies>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>integration-test</goal>
+                                    </goals>
+                                    <configuration>
+                                        <skip>false</skip>
+                                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                        <forkCount>0</forkCount>
+                                        <systemPropertyVariables combine.children="append">
+                                            <project.version>${project.version}</project.version>
+                                            <project.build.directory>${project.build.directory}</project.build.directory>
+                                            <version.org.jboss.narayana>${version.org.jboss.narayana}</version.org.jboss.narayana>
+                                            <version.org.jboss.resteasy>${version.org.jboss.resteasy}</version.org.jboss.resteasy>
+                                            <version.org.jboss.spec.javax.transaction>${version.org.jboss.spec.javax.transaction}</version.org.jboss.spec.javax.transaction>
+                                            <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                            <tomcat.user>arquillian</tomcat.user>
+                                            <tomcat.pass>arquillian</tomcat.pass>
+                                            <db.timeout.waiting.for.heartbeat.statement>120000</db.timeout.waiting.for.heartbeat.statement>
+                                            <db.timeout.heartbeat.statement>SELECT 1;</db.timeout.heartbeat.statement>
+                                        </systemPropertyVariables>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>verify</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>verify</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>false</skip>
-                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                                    <forkCount>0</forkCount>
-                                    <systemPropertyVariables combine.children="append">
-                                        <project.version>${project.version}</project.version>
-                                        <project.build.directory>${project.build.directory}</project.build.directory>
-                                        <version.org.jboss.narayana>${version.org.jboss.narayana}</version.org.jboss.narayana>
-                                        <version.org.jboss.resteasy>${version.org.jboss.resteasy}</version.org.jboss.resteasy>
-                                        <version.org.jboss.spec.javax.transaction>${version.org.jboss.spec.javax.transaction}</version.org.jboss.spec.javax.transaction>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <tomcat.user>arquillian</tomcat.user>
-                                        <tomcat.pass>arquillian</tomcat.pass>
-
-                                        <!--
-                                        h2:
-                                          By default, the integration test runs with "h2" database, platform independent and in-memory.
-                                        pgsql:
-                                          If selected, the TS runs against a remote, always present PostgreSQL database server available in the Narayana CI.
-                                        container:
-                                          It requires a running Docker daemon the user executing this TS has the rights to control
-                                          A database is started as a Docker container and it is discarded at the end of testing.
-                                        dballocator:
-                                          It requires an instance of DBAllocator running in your infrastructure. It enables the TS to
-                                          lease various databases, including but not limited to Sybase, DB2, MS SQL, Maria, Postgress, Oracle...
-                                        -->
-                                        <test.db.type>h2</test.db.type>
-
-                                        <!-- pgsql properties -->
-                                        <version.postgresql>${version.postgresql}</version.postgresql>
-                                        <pgsql.user>dtf11</pgsql.user>
-                                        <pgsql.password>dtf11</pgsql.password>
-                                        <pgsql.servername>narayanaci1.eng.hst.ams2.redhat.com</pgsql.servername>
-                                        <pgsql.portnumber>5432</pgsql.portnumber>
-                                        <pgsql.databasename>jbossts</pgsql.databasename>
-
-                                        <!-- h2 properties -->
-                                        <version.com.h2database>${version.com.h2database}</version.com.h2database>
-
-                                        <!-- container properties -->
-                                        <container.database.image>postgres:10</container.database.image>
-                                        <container.database.driver.artifact>org.postgresql:postgresql:42.2.2</container.database.driver.artifact>
-                                        <container.database.driver.class>org.postgresql.Driver</container.database.driver.class>
-                                        <container.database.datasource.class.xa>org.postgresql.xa.PGXADataSource</container.database.datasource.class.xa>
-                                        <container.docker.daemon.api.url>tcp://127.0.0.1:2375</container.docker.daemon.api.url>
-                                        <container.name>narayana_db</container.name>
-                                        <container.database.username>narayana_user</container.database.username>
-                                        <container.database.password>narayana_pass</container.database.password>
-                                        <container.database.name>narayana_db</container.database.name>
-                                        <container.database.bind.host.ip>127.0.0.1</container.database.bind.host.ip>
-                                        <container.database.bind.host.port>5432</container.database.bind.host.port>
-                                        <!-- The undermentioned timeout accounts both for pulling image and starting container up to opened socket. -->
-                                        <container.timeout.waiting.for.tcp>240000</container.timeout.waiting.for.tcp>
-
-                                        <db.timeout.waiting.for.heartbeat.statement>120000</db.timeout.waiting.for.heartbeat.statement>
-                                        <db.timeout.heartbeat.statement>SELECT 1;</db.timeout.heartbeat.statement>
-
-                                        <!-- dballocator properties -->
-                                        <dballocator.host.port>http://your.db.allocator.example.com:8080</dballocator.host.port>
-                                        <dballocator.expression>postgresql94</dballocator.expression>
-                                        <dballocator.requestee>narayana-tomcat-ts</dballocator.requestee>
-                                        <dballocator.expiry.minutes>10</dballocator.expiry.minutes>
-                                        <dballocator.timeout.minutes>20</dballocator.timeout.minutes>
-                                        <dballocator.driver.url>http://your.fileserver.example.com/postgresql-42.1.1.jar</dballocator.driver.url>
-                                        <dballocator.driver.url.timeout.seconds>120</dballocator.driver.url.timeout.seconds>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>verify</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -337,6 +314,170 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>externalDatabase</id>
+            <activation>
+                <property>
+                    <name>test.db.type</name>
+                    <value>external</value>
+                </property>
+            </activation>
+            <properties>
+                <datasource.classname>org.h2.jdbcx.JdbcDataSource</datasource.classname>
+                <jdbc.driver.class>org.h2.Driver</jdbc.driver.class>
+                <jdbc.db.name/>
+                <jdbc.db.port/>
+                <jdbc.db.server/>
+                <jdbc.driver.jar/>
+                <jdbc.username>sa</jdbc.username>
+                <jdbc.password>sa</jdbc.password>
+                <jdbc.url>jdbc:h2:tcp://localhost/${project.basedir}/target/test-db;MVCC=TRUE</jdbc.url>
+                <jdbc.schema>public</jdbc.schema>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables combine.children="append">
+                                    <datasource.classname>${datasource.classname}</datasource.classname>
+                                    <jdbc.driver.class>${jdbc.driver.class}</jdbc.driver.class>
+                                    <jdbc.db.name>${jdbc.db.name}</jdbc.db.name>
+                                    <jdbc.db.port>${jdbc.db.port}</jdbc.db.port>
+                                    <jdbc.db.server>${jdbc.db.server}</jdbc.db.server>
+                                    <jdbc.driver.jar>${jdbc.driver.jar}</jdbc.driver.jar>
+                                    <jdbc.username>${jdbc.username}</jdbc.username>
+                                    <jdbc.password>${jdbc.password}</jdbc.password>
+                                    <jdbc.url>${jdbc.url}</jdbc.url>
+                                    <jdbc.schema>${jdbc.schema}</jdbc.schema>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>h2Database</id>
+            <activation>
+                <property>
+                    <name>test.db.type</name>
+                    <value>h2</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables combine.children="append">
+                                    <version.com.h2database>${version.com.h2database}</version.com.h2database>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>postgresql</id>
+            <activation>
+                <property>
+                    <name>test.db.type</name>
+                    <value>pgsql</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables combine.children="append">
+                                    <version.postgresql>${version.postgresql}</version.postgresql>
+                                    <pgsql.user>dtf11</pgsql.user>
+                                    <pgsql.password>dtf11</pgsql.password>
+                                    <pgsql.servername>narayanaci1.eng.hst.ams2.redhat.com</pgsql.servername>
+                                    <pgsql.portnumber>5432</pgsql.portnumber>
+                                    <pgsql.databasename>jbossts</pgsql.databasename>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>container</id>
+            <activation>
+                <property>
+                    <name>test.db.type</name>
+                    <value>container</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables combine.children="append">
+                                    <container.database.image>postgres:10</container.database.image>
+                                    <container.database.driver.artifact>org.postgresql:postgresql:42.2.2</container.database.driver.artifact>
+                                    <container.database.driver.class>org.postgresql.Driver</container.database.driver.class>
+                                    <container.database.datasource.class.xa>org.postgresql.xa.PGXADataSource</container.database.datasource.class.xa>
+                                    <container.docker.daemon.api.url>tcp://127.0.0.1:2375</container.docker.daemon.api.url>
+                                    <container.name>narayana_db</container.name>
+                                    <container.database.username>narayana_user</container.database.username>
+                                    <container.database.password>narayana_pass</container.database.password>
+                                    <container.database.name>narayana_db</container.database.name>
+                                    <container.database.bind.host.ip>127.0.0.1</container.database.bind.host.ip>
+                                    <container.database.bind.host.port>5432</container.database.bind.host.port>
+                                    <!-- The undermentioned timeout accounts both for pulling image and starting container up to opened socket. -->
+                                    <container.timeout.waiting.for.tcp>240000</container.timeout.waiting.for.tcp>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>dballocator</id>
+            <activation>
+                <property>
+                    <name>test.db.type</name>
+                    <value>dballocator</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables combine.children="append">
+                                    <dballocator.host.port>http://your.db.allocator.example.com:8080</dballocator.host.port>
+                                    <dballocator.expression>postgresql94</dballocator.expression>
+                                    <dballocator.requestee>narayana-tomcat-ts</dballocator.requestee>
+                                    <dballocator.expiry.minutes>10</dballocator.expiry.minutes>
+                                    <dballocator.timeout.minutes>20</dballocator.timeout.minutes>
+                                    <dballocator.driver.url>http://your.fileserver.example.com/postgresql-42.1.1.jar</dballocator.driver.url>
+                                    <dballocator.driver.url.timeout.seconds>120</dballocator.driver.url.timeout.seconds>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
         <profile>

--- a/tools/src/main/java/io/narayana/db/Allocator.java
+++ b/tools/src/main/java/io/narayana/db/Allocator.java
@@ -70,6 +70,8 @@ public abstract class Allocator {
             dbAllocator = new PostgreContainerAllocator();
         } else if ("dballocator".equals(mode)) {
             dbAllocator = new DBAllocator();
+        } else if ("external".equals(mode)) {
+            dbAllocator = new ExternalDBAllocator();
         } else {
             throw new IllegalArgumentException("Unknown operation mode, expected pgsql or h2 or container or dballocator but it was: " + mode);
         }

--- a/tools/src/main/java/io/narayana/db/CIPostgreAllocator.java
+++ b/tools/src/main/java/io/narayana/db/CIPostgreAllocator.java
@@ -28,12 +28,13 @@ package io.narayana.db;
  *
  * @author <a href="mailto:karm@redhat.com">Michal Karm Babacek</a>
  */
-public class CIPostgreAllocator extends Allocator {
+public class CIPostgreAllocator extends DefaultAllocator {
 
     CIPostgreAllocator() {
         // Use getInstance
     }
 
+    @Override
     public DB allocateDB(final int expiryMinutes) {
         final String versionPostgreSQLDriver = getProp("version.postgresql");
         final String user = getProp("pgsql.user");
@@ -60,29 +61,5 @@ public class CIPostgreAllocator extends Allocator {
                 .tdsType("javax.sql.XADataSource")
                 .dbDriverArtifact("postgresql:postgresql:" + versionPostgreSQLDriver)
                 .build();
-    }
-
-    public DB allocateDB() {
-        return allocateDB(0);
-    }
-
-    public boolean deallocateDB(final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean reallocateDB(final int expiryMinutes, final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean reallocateDB(final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean cleanDB(final DB db) {
-        // Intentionally nothing
-        return true;
     }
 }

--- a/tools/src/main/java/io/narayana/db/DB.java
+++ b/tools/src/main/java/io/narayana/db/DB.java
@@ -39,6 +39,7 @@ public class DB {
     public final String dsLoginTimeout;
     public final String dsFactory;
     public final String dsDriverClassName;
+    public final String dsSchema;
     public final String tdsType;
     public final String tdsUrl;
     public final String tdsDriverClassName;
@@ -58,6 +59,7 @@ public class DB {
         private String dsLoginTimeout;
         private String dsFactory;
         private String dsDriverClassName;
+        public  String dsSchema;
         private String tdsType;
         private String tdsUrl;
         private String tdsDriverClassName;
@@ -120,6 +122,11 @@ public class DB {
             return this;
         }
 
+        Builder dsSchema(String dsSchema) {
+            this.dsSchema = dsSchema;
+            return this;
+        }
+
         Builder tdsType(String tdsType) {
             this.tdsType = tdsType;
             return this;
@@ -167,6 +174,7 @@ public class DB {
         this.dsLoginTimeout = builder.dsLoginTimeout;
         this.dsFactory = builder.dsFactory;
         this.dsDriverClassName = builder.dsDriverClassName;
+        this.dsSchema = builder.dsSchema;
         this.tdsType = builder.tdsType;
         this.tdsUrl = builder.tdsUrl;
         this.tdsDriverClassName = builder.tdsDriverClassName;

--- a/tools/src/main/java/io/narayana/db/DefaultAllocator.java
+++ b/tools/src/main/java/io/narayana/db/DefaultAllocator.java
@@ -1,0 +1,33 @@
+package io.narayana.db;
+
+abstract class DefaultAllocator extends Allocator {
+
+    @Override
+    public DB allocateDB() {
+        return allocateDB(0);
+    }
+
+    @Override
+    public boolean deallocateDB(final DB db) {
+        // Intentionally nothing
+        return true;
+    }
+
+    @Override
+    public boolean reallocateDB(final int expiryMinutes, final DB db) {
+        // Intentionally nothing
+        return true;
+    }
+
+    @Override
+    public boolean reallocateDB(final DB db) {
+        // Intentionally nothing
+        return true;
+    }
+
+    @Override
+    public boolean cleanDB(final DB db) {
+        // Intentionally nothing
+        return true;
+    }
+}

--- a/tools/src/main/java/io/narayana/db/ExternalDBAllocator.java
+++ b/tools/src/main/java/io/narayana/db/ExternalDBAllocator.java
@@ -1,0 +1,24 @@
+package io.narayana.db;
+
+public class ExternalDBAllocator extends DefaultAllocator {
+
+    @Override
+    public DB allocateDB(final int expiryMinutes) {
+        final String user = System.getProperty("jdbc.username");
+        return new DB.Builder()
+                .dsType(System.getProperty("datasource.classname"))
+                .dsUsername(user)
+                .dsUser(user)
+                .dsPassword(System.getProperty("jdbc.password"))
+                .dsDbName(System.getProperty("jdbc.db.name"))
+                .dsDbPort(System.getProperty("jdbc.db.port"))
+                .dsDbHostname(System.getProperty("jdbc.db.server"))
+                .dsUrl(System.getProperty("jdbc.url"))
+                .dsLoginTimeout("0")
+                .dsDriverClassName(System.getProperty("jdbc.driver.class"))
+                .dsSchema(System.getProperty("jdbc.schema"))
+                .tdsType("javax.sql.XADataSource")
+                .dbDriverArtifact(System.getProperty("jdbc.driver.jar"))
+                .build();
+    }
+}

--- a/tools/src/main/java/io/narayana/db/H2Allocator.java
+++ b/tools/src/main/java/io/narayana/db/H2Allocator.java
@@ -25,12 +25,13 @@ package io.narayana.db;
 /**
  * @author <a href="mailto:karm@redhat.com">Michal Karm Babacek</a>
  */
-public class H2Allocator extends Allocator {
+public class H2Allocator extends DefaultAllocator {
 
     H2Allocator() {
         // Use getInstance
     }
 
+    @Override
     public DB allocateDB(final int expiryMinutes) {
         final String versionComH2database = getProp("version.com.h2database");
         return new DB.Builder()
@@ -45,29 +46,5 @@ public class H2Allocator extends Allocator {
                 .tdsType("javax.sql.XADataSource")
                 .dbDriverArtifact("com.h2database:h2:" + versionComH2database)
                 .build();
-    }
-
-    public DB allocateDB() {
-        return allocateDB(0);
-    }
-
-    public boolean deallocateDB(final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean reallocateDB(final int expiryMinutes, final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean reallocateDB(final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean cleanDB(final DB db) {
-        // Intentionally nothing
-        return true;
     }
 }

--- a/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
+++ b/tools/src/main/java/io/narayana/db/PostgreContainerAllocator.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 /**
  * @author <a href="mailto:karm@redhat.com">Michal Karm Babacek</a>
  */
-public class PostgreContainerAllocator extends Allocator {
+public class PostgreContainerAllocator extends DefaultAllocator {
     private static final Logger LOGGER = Logger.getLogger(PostgreContainerAllocator.class.getName());
 
     private final DockerClient dockerClient;
@@ -74,6 +74,7 @@ public class PostgreContainerAllocator extends Allocator {
                 .build();
     }
 
+    @Override
     public DB allocateDB(final int expiryMinutes) {
         final String projectBuildDirectory = getProp("project.build.directory");
         final File driversDir = new File(projectBuildDirectory);
@@ -233,10 +234,7 @@ public class PostgreContainerAllocator extends Allocator {
                 .build();
     }
 
-    public DB allocateDB() {
-        return allocateDB(0);
-    }
-
+    @Override
     public boolean deallocateDB(final DB db) {
         final String containerName = getProp("container.name");
         LOGGER.info("Listing containers for deallocation.");
@@ -259,16 +257,7 @@ public class PostgreContainerAllocator extends Allocator {
         return true;
     }
 
-    public boolean reallocateDB(final int expiryMinutes, final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
-    public boolean reallocateDB(final DB db) {
-        // Intentionally nothing
-        return true;
-    }
-
+    @Override
     public boolean cleanDB(final DB db) {
         final String containerName = getProp("container.name");
         final String containerDatabaseBindHostPort = getProp("container.database.bind.host.port");


### PR DESCRIPTION
- adds the ability to work with an external database
- splits failsafe plugin configuration into separate profiles by test.db.type

@Karm would you kindly review?