### PR TITLE
Update web-servers with commits from jbosstm:master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
         <version.checkstyle>8.5</version.checkstyle>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
-        <version.org.jacoco>0.8.2</version.org.jacoco>
+        <version.org.jacoco>0.8.8</version.org.jacoco>
         <version.simple-jndi>0.11.4.1</version.simple-jndi>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.org.jboss.narayana>5.9.11.Final</version.org.jboss.narayana>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
         <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.18</version.org.jboss.byteman>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.resteasy>3.1.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.arquillian.core>1.1.7.Final</version.org.jboss.arquillian.core>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <name>Narayana: Tomcat integration</name>
     <properties>
         <version.org.apache.tomcat>9.0.13</version.org.apache.tomcat>
-        <version.org.jboss.narayana>5.9.0.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.9.11.Final</version.org.jboss.narayana>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
         <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>


### PR DESCRIPTION
For my testing which used a version of Maven that has the `central` repo overridden so access goes over https, this change did seem likely it stopped the resolver using http for `central` as it seemed to stop getting a 501 warning