### PR TITLE
Add a basic dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+
+  # for alternative branch
+  - package-ecosystem: "maven"
+    target-branch: "jws-narayana-tests"
+    directory: "/"
+    ignore:
+      - dependency-name: org.jboss.narayana
+        versions:
+          - "> 5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+


### PR DESCRIPTION
You can see some of the PRs that would be opened after merging this [here](https://github.com/jajik/narayana-tomcat/pulls). The default limit for open PRs is 5 (per update config), so after merging/closing some, additional may appear at the beginning.

As you can see, you can exclude some dependencies or versions from the pool. Full documentation is available [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

I'm opening this as a draft so that it won't get merged by accident before we discuss whether we want this and what should be the policy for the two branches.